### PR TITLE
Fix - Multiple listen directives

### DIFF
--- a/templates/vhost.j2
+++ b/templates/vhost.j2
@@ -12,7 +12,18 @@ server {
     {% block server_begin %}{% endblock %}
 
     {% block server_basic -%}
-    listen {{ item.listen | default('80') }};
+
+{% if item.listen is defined %}
+  {% if item.listen is string %}
+    listen {{ item.listen }};
+  {% elif item.listen | length >= 1 %}
+    {% for listen_port in item.listen %}
+    listen {{ listen_port }};
+    {% endfor %}
+  {% endif %}
+{% else %}
+    listen 80;
+{% endif %}
 
 {% if item.server_name is defined %}
     server_name {{ item.server_name }};


### PR DESCRIPTION
This fixes the listed directives to add more than one listen directive:

1. listen can be absent so a default value of 80 will be used,

2. listen can be a string like 
```
nginx_vhosts:
  - listen: 443 ssl http2
```

3. listen can be a list:
```
nginx_vhosts:
  - listen:
      - 80
      - 443 ssl http2
```

Fixes #138